### PR TITLE
Enable usage of machine set CRATES var

### DIFF
--- a/ci/run_task.sh
+++ b/ci/run_task.sh
@@ -64,7 +64,7 @@ main() {
         # can't find the file because of the ENV var
         # shellcheck source=/dev/null
         . "$crates_script"
-        for crate in "${CRATES[@]}"; do
+        for crate in $CRATES; do
             verbose_say "Found crate: $crate"
         done
     else
@@ -111,7 +111,7 @@ main() {
 
 # Build and test for each crate, done with each toolchain.
 build_and_test() {
-    for crate in "${CRATES[@]}"; do
+    for crate in $CRATES; do
         local test_vars_script="$REPO_DIR/$crate/contrib/test_vars.sh"
 
         # Clean variables and also make sure they are defined.
@@ -287,7 +287,7 @@ build_docs_with_stable_toolchain() {
 do_bench() {
     verbose_say "Running bench tests for: $CRATES"
 
-    for crate in "${CRATES[@]}"; do
+    for crate in $CRATES; do
         pushd "$REPO_DIR/$crate" > /dev/null
         # Unit tests are ignored so if there are no bench test then this will just succeed.
         RUSTFLAGS='--cfg=bench' cargo bench


### PR DESCRIPTION
Repos using the `run_task` script would like to set the `CRATES` env var by using

```bash
REPO_DIR=$(git rev-parse --show-toplevel)
CRATES="$(cargo metadata --no-deps --format-version 1 | jq -j -r '.packages | map(.manifest_path | rtrimstr("/Cargo.toml") | ltrimstr("'"$REPO_DIR"'/")) | join(" ")')"
```

I don't know exactly why but this results in some sort of square braces data type that seems to only work in a loop using `for crate in $CRATES` instead of the `for crate in ${CRATES[@]}` like we currently have.