### PR TITLE
Add `-j1` to docs build invocation

### DIFF
--- a/ci/run_task.sh
+++ b/ci/run_task.sh
@@ -273,14 +273,15 @@ do_dup_deps() {
 # below this checks that we feature guarded docs imports correctly.
 build_docs_with_nightly_toolchain() {
     need_nightly
-    RUSTDOCFLAGS="--cfg docsrs -D warnings -D rustdoc::broken-intra-doc-links" $cargo doc --all-features
+    # -j1 is because docs build fails if multiple versions of `bitcoin_hashes` are present in dep tree.
+    RUSTDOCFLAGS="--cfg docsrs -D warnings -D rustdoc::broken-intra-doc-links" $cargo doc --all-features -j1
 }
 
 # Build the docs with a stable toolchain, in unison with the function
 # above this checks that we feature guarded docs imports correctly.
 build_docs_with_stable_toolchain() {
     local cargo="cargo +stable --locked" # Can't use global because of `+stable`.
-    RUSTDOCFLAGS="-D warnings" $cargo doc --all-features
+    RUSTDOCFLAGS="-D warnings" $cargo doc --all-features -j1
 }
 
 # Bench only works with a non-stable toolchain (nightly, beta).


### PR DESCRIPTION
After upgrade of `hashes` but before we upgrade it in `secp` we get multiple versions in the dep tree. This makes the docs build choke because output directory uses the name of the crate (without the version) which then conflicts and causes the build to fail.

Adding `-j1` so that only a single job is run when building the docs resolves the issue.