### PR TITLE
ci: Build and test with all features

### DIFF
--- a/ci/run_task.sh
+++ b/ci/run_task.sh
@@ -184,6 +184,9 @@ do_feature_matrix() {
         $cargo test --no-default-features
     fi
 
+    $cargo build --all-features
+    $cargo test --all-features
+
     if [ -n "${FEATURES_WITH_STD}" ]; then
         loop_features "std" "${FEATURES_WITH_STD}"
     fi


### PR DESCRIPTION
We test various combinations of features in the feature matrix but somehow we forgot to build and test with `--all-features`. We do lint with all features so this is not a massive fail but its a fail none the less.

Discovered by Andrew's CI while reviewing recent changes to `corepc`.