### PR TITLE
Add toolchain check and crates parameter

### DIFF
--- a/ci/run_task.sh
+++ b/ci/run_task.sh
@@ -57,11 +57,15 @@ main() {
     local task="${1:-usage}"
     local crates_script="$REPO_DIR/contrib/crates.sh"
 
-    # FIXME: This is a hackish way to get the help flag.
-    if [ "$task" = "usage" ] || [ "$task" = "-h" ] || [ "$task" = "--help" ]; then
-        usage
-        exit 0
-    fi
+    # Check for help flags in any position.
+    for arg in "$@"; do
+        case "$arg" in
+            -h|--help|help|usage)
+                usage
+                exit 0
+                ;;
+        esac
+    done
 
     check_required_commands
 


### PR DESCRIPTION
The fact that the `stable`, `nightly`, and `msrv` tasks were essentially the same was making me twitch a bit, so added toolchain validation to ensure they are being called with the intended toolchain.

Added an optional `CRATE` array parameter to run a task on a subset of crates. This allows for things like MSRV checks on crates with different MSRVs in a workspace. It also allows for quick tests on a crate you are hacking on. I believe this is enough to enable some quick and quiet local test cycles.