### PR TITLE
tasks: allow user to not set all configs

### DIFF
--- a/tasks/src/lint.rs
+++ b/tasks/src/lint.rs
@@ -6,13 +6,15 @@ use crate::quiet_cmd;
 use crate::toolchain::{check_toolchain, Toolchain};
 
 /// Lint configuration loaded from contrib/rbmt.toml.
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Default)]
+#[serde(default)]
 struct Config {
     lint: LintConfig,
 }
 
 /// Lint-specific configuration.
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, Default)]
+#[serde(default)]
 struct LintConfig {
     /// List of crate names that are allowed to have duplicate versions.
     allowed_duplicates: Vec<String>,

--- a/tasks/src/test.rs
+++ b/tasks/src/test.rs
@@ -8,13 +8,15 @@ use std::path::Path;
 use xshell::Shell;
 
 /// Test configuration loaded from contrib/rbmt.toml.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
 struct Config {
     test: TestConfig,
 }
 
 /// Test-specific configuration.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
 struct TestConfig {
     /// Examples to run with the format "name:feature1 feature2".
     ///


### PR DESCRIPTION
Been testing out integration and realized it's a pain to have to set all un-used config settings to empty lists.

Example from rust-psbt where I don't want to set `exact_features` and `features_with_no_std`:

```
features_with_std = ["rand", "serde", "base64", "miniscript"]
features_without_std = ["serde", "base64"]
exact_features = []
features_with_no_std = []
```