### PR TITLE
cargo-rbmt: add `--no-deps` to `cargo doc` invocations

### DIFF
--- a/cargo-rbmt/src/docs.rs
+++ b/cargo-rbmt/src/docs.rs
@@ -11,7 +11,7 @@ use xshell::Shell;
 pub fn run(sh: &Shell, packages: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     check_toolchain(sh, Toolchain::Stable)?;
 
-    let mut cmd = quiet_cmd!(sh, "cargo doc --all-features");
+    let mut cmd = quiet_cmd!(sh, "cargo doc --all-features --no-deps");
 
     // Add package filters if specified.
     for package in packages {
@@ -30,7 +30,7 @@ pub fn run(sh: &Shell, packages: &[String]) -> Result<(), Box<dyn std::error::Er
 pub fn run_docsrs(sh: &Shell, packages: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     check_toolchain(sh, Toolchain::Nightly)?;
 
-    let mut cmd = quiet_cmd!(sh, "cargo doc --all-features");
+    let mut cmd = quiet_cmd!(sh, "cargo doc --all-features --no-deps");
 
     // Add package filters if specified.
     for package in packages {


### PR DESCRIPTION
With this change, we need to remove `doc_auto_cfg` from the crates that we actively maintain, but don't need to do it for their dependencies.

Fixes #31