### PR TITLE
No more build before test and lock dependencies

### DIFF
--- a/cargo-rbmt/src/bench.rs
+++ b/cargo-rbmt/src/bench.rs
@@ -1,7 +1,6 @@
 //! Benchmark testing tasks.
 
-use crate::environment::{get_crate_dirs, quiet_println};
-use crate::quiet_cmd;
+use crate::environment::{cargo, get_crate_dirs, quiet_println};
 use crate::toolchain::{check_toolchain, Toolchain};
 use xshell::Shell;
 
@@ -22,7 +21,7 @@ pub fn run(sh: &Shell, packages: &[String]) -> Result<(), Box<dyn std::error::Er
         // Use pushd pattern to change and restore directory.
         let _dir = sh.push_dir(crate_dir);
 
-        quiet_cmd!(sh, "cargo bench")
+        cargo(sh, "bench")
             .env("RUSTFLAGS", "--cfg=bench")
             .run()?;
     }

--- a/cargo-rbmt/src/docs.rs
+++ b/cargo-rbmt/src/docs.rs
@@ -1,6 +1,6 @@
 //! Documentation building tasks.
 
-use crate::quiet_cmd;
+use crate::environment::cargo;
 use crate::toolchain::{check_toolchain, Toolchain};
 use xshell::Shell;
 
@@ -11,7 +11,7 @@ use xshell::Shell;
 pub fn run(sh: &Shell, packages: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     check_toolchain(sh, Toolchain::Stable)?;
 
-    let mut cmd = quiet_cmd!(sh, "cargo doc --all-features --no-deps");
+    let mut cmd = cargo(sh, "doc --all-features --no-deps");
 
     // Add package filters if specified.
     for package in packages {
@@ -30,7 +30,7 @@ pub fn run(sh: &Shell, packages: &[String]) -> Result<(), Box<dyn std::error::Er
 pub fn run_docsrs(sh: &Shell, packages: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     check_toolchain(sh, Toolchain::Nightly)?;
 
-    let mut cmd = quiet_cmd!(sh, "cargo doc --all-features --no-deps");
+    let mut cmd = cargo(sh, "doc --all-features --no-deps");
 
     // Add package filters if specified.
     for package in packages {

--- a/cargo-rbmt/src/environment.rs
+++ b/cargo-rbmt/src/environment.rs
@@ -94,3 +94,11 @@ pub fn get_crate_dirs(
 
     Ok(crate_dirs)
 }
+
+/// Helper function to run cargo commands with CI flags.
+///
+/// The locked flag ensures using existing Cargo.lock file without
+/// updating dependencies.
+pub fn cargo<'a>(sh: &'a Shell, args: &str) -> xshell::Cmd<'a> {
+    quiet_cmd!(sh, "cargo --locked {args}")
+}

--- a/cargo-rbmt/src/integration.rs
+++ b/cargo-rbmt/src/integration.rs
@@ -1,7 +1,6 @@
 //! Integration test tasks for packages with bitcoind-tests or similar test packages.
 
-use crate::environment::{get_crate_dirs, quiet_println, CONFIG_FILE_PATH};
-use crate::quiet_cmd;
+use crate::environment::{cargo, get_crate_dirs, quiet_println, CONFIG_FILE_PATH};
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use xshell::{cmd, Shell};
@@ -110,7 +109,7 @@ pub fn run(sh: &Shell, packages: &[String]) -> Result<(), Box<dyn std::error::Er
         // Run tests for each version.
         for version in &versions_to_test {
             quiet_println(&format!("  Testing with version: {}", version));
-            quiet_cmd!(sh, "cargo test --features={version}").run()?;
+            cargo(sh, "test --features={version}").run()?;
         }
     }
 

--- a/cargo-rbmt/src/lock.rs
+++ b/cargo-rbmt/src/lock.rs
@@ -1,4 +1,8 @@
 //! Manage cargo lock files for minimal and recent dependency versions.
+//!
+//! Note: This module uses `quiet_cmd!` directly instead of the `cargo()` helper
+//! because these commands intentionally generate and modify lockfiles. Using
+//! `--locked` would prevent the dependency resolution we need here.
 
 use crate::environment::quiet_println;
 use crate::quiet_cmd;


### PR DESCRIPTION
Two little cleanups which I hope make it easier to add some release/debug_assert settings.

First patch drops the `build`s before running `test`. I don't think there is any benefit of this, but maybe there was historically or I am just missing something?

Second patch makes sure we are using `--locked` everywhere so that dependencies are never silently upgraded in CI.