### PR TITLE
Share github setup action

### DIFF
--- a/.github/actions/setup-rbmt/action.yml
+++ b/.github/actions/setup-rbmt/action.yml
@@ -1,0 +1,52 @@
+name: 'Setup rbmt'
+description: |
+  Install environment dependencies for cargo-rbmt testing including cargo-rbmt itself.
+inputs:
+  toolchains:
+    description: 'Rust toolchain versions, comma-separated (nightly,1.74.0)'
+    required: false
+    default: 'stable'
+  components:
+    description: 'Additional Rust components, comma-separated (clippy,rustfmt)'
+    required: false
+    default: ''
+  rbmt-version:
+    description: 'Git ref (commit, tag, or branch) of cargo-rbmt to install'
+    required: false
+    default: 'master'
+
+runs:
+  using: "composite"
+  steps:
+    # Cache ARM toolchain apt packages for faster subsequent runs.
+    - name: Cache ARM toolchain packages
+      uses: actions/cache@v5
+      with:
+        path: /var/cache/apt/archives
+        key: ${{ runner.os }}-apt-arm-toolchain-v1
+        restore-keys: |
+          ${{ runner.os }}-apt-arm-toolchain-
+
+    # Setup Rust with automatic caching of toolchains and build artifacts.
+    # Always install stable for cargo-rbmt, plus the requested toolchain.
+    - name: Setup Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable,${{ inputs.toolchains }}
+        components: rust-src,${{ inputs.components }}
+        # ARM target to test no-std build.
+        target: thumbv7m-none-eabi
+
+    # Install ARM cross-compiler for no-std testing.
+    - name: Install ARM cross-compiler
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-arm-none-eabi
+        echo "CC_thumbv7m_none_eabi=arm-none-eabi-gcc" >> $GITHUB_ENV
+
+    # Install cargo-rbmt using stable toolchain.
+    - name: Install cargo-rbmt
+      shell: bash
+      run: |
+        cargo +stable install --git https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools.git --rev ${{ inputs.rbmt-version }} cargo-rbmt --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Rust toolchains
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Dogfood the setup-rbmt action
+        uses: ./.github/actions/setup-rbmt
         with:
-          toolchain: nightly,1.85.0,stable
+          toolchains: nightly,1.85.0
           components: clippy,rustfmt
-
-      - name: Install cargo-rbmt from current commit
-        run: cargo install --locked --path cargo-rbmt
+          rbmt-version: ${{ github.sha }}
 
       - name: Run lint on workspace
         run: cargo +nightly rbmt --lock-file existing lint

--- a/cargo-rbmt/README.md
+++ b/cargo-rbmt/README.md
@@ -14,6 +14,7 @@ Maintainer tools for Rust-based projects in the Bitcoin domain. Built with [xshe
 - [Workspace Integration](#workspace-integration)
   - [1. Install on system](#1-install-on-system)
   - [2. Add as a dev-dependency](#2-add-as-a-dev-dependency)
+- [GitHub Action](#github-action)
 
 ## Environment Variables
 
@@ -187,3 +188,18 @@ cargo run --bin cargo-rbmt -- lint
 ```
 
 It might be worth wrapping in an [xtask](https://github.com/matklad/cargo-xtask) package for a clean interface.
+
+## GitHub Action
+
+A composite action is provided to make it easy to use `cargo-rbmt` in Github Actions CI.
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/setup-rbmt@master
+    with:
+      toolchains: stable
+  - run: cargo rbmt test stable
+```
+
+See the [action](../.github/actions/setup-rbmt/action.yml) for more details.


### PR DESCRIPTION
I learned that you can reference github composite actions from other repos, so figured I'd centralize this setup action that is starting to gain some dependencies.