### PR TITLE
run_task: Add --no-deps to docs build

### DIFF
--- a/ci/run_task.sh
+++ b/ci/run_task.sh
@@ -309,7 +309,7 @@ do_dup_deps() {
 build_docs_with_nightly_toolchain() {
     need_nightly
     # -j1 is because docs build fails if multiple versions of `bitcoin_hashes` are present in dep tree.
-    RUSTDOCFLAGS="--cfg docsrs -D warnings -D rustdoc::broken-intra-doc-links" $cargo doc --all-features -j1
+    RUSTDOCFLAGS="--cfg docsrs -D warnings -D rustdoc::broken-intra-doc-links" $cargo doc --no-deps --all-features -j1
 }
 
 # Build the docs with a stable toolchain, in unison with the function


### PR DESCRIPTION
Add `--no-deps` when building docs with nightly toolchain so that if any dependency uses `doc_auto_cfg` still then the build will not choke.

In `bitcoin` the `rand` dep is breaking nightly docs build.