### PR TITLE
Fix dangling comma when no toolchains passed to action

### DIFF
--- a/.github/actions/setup-rbmt/action.yml
+++ b/.github/actions/setup-rbmt/action.yml
@@ -62,7 +62,7 @@ runs:
     - name: Setup Rust toolchains
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        toolchain: ${{ steps.determine-versions.outputs.nightly }},${{ steps.determine-versions.outputs.stable }},${{ inputs.toolchains }}
+        toolchain: ${{ steps.determine-versions.outputs.nightly }},${{ steps.determine-versions.outputs.stable }}${{ inputs.toolchains && format(',{0}', inputs.toolchains) || '' }}
         components: rust-src,clippy,rustfmt
         # ARM target to test no-std build.
         target: thumbv7m-none-eabi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Dogfood the setup-rbmt action
+      - name: Dogfood with cargo-rbmt
         id: setup
         uses: ./.github/actions/setup-rbmt
         with:
-          toolchains: 1.85.0
           rbmt-version: ${{ github.sha }}
 
       - name: Run lint on workspace
@@ -33,11 +32,23 @@ jobs:
       - name: Run tests with nightly (existing lock)
         run: cargo +${{ steps.setup.outputs.nightly-version }} rbmt --lock-file existing test nightly
 
-      - name: Run tests with MSRV (existing lock)
-        run: cargo +1.85.0 rbmt --lock-file existing test msrv
-
       - name: Run tests with stable (recent dependencies)
         run: cargo +${{ steps.setup.outputs.stable-version }} rbmt --lock-file recent test stable
 
       - name: Run tests with stable (minimal dependencies)
         run: cargo +${{ steps.setup.outputs.stable-version }} rbmt --lock-file minimal test stable
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Dogfood with MSRV toolchain
+        id: setup
+        uses: ./.github/actions/setup-rbmt
+        with:
+          toolchains: 1.85.0
+          rbmt-version: ${{ github.sha }}
+
+      - name: Run tests with MSRV (existing lock)
+        run: cargo +1.85.0 rbmt --lock-file existing test msrv


### PR DESCRIPTION
Split up the dogfood CI to test this case.