### PR TITLE
cargo-rbmt: update no-std check to build

### DIFF
--- a/.github/actions/setup-rbmt/action.yml
+++ b/.github/actions/setup-rbmt/action.yml
@@ -73,9 +73,13 @@ runs:
       run: |
         cargo +${{ steps.determine-versions.outputs.stable }} install --git https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools.git --rev ${{ steps.determine-versions.outputs.rbmt }} cargo-rbmt --locked
 
-    - name: Install additional cross compiler packages
+    # ARM cross-compiler for C dependencies compiled at build-time (e.g. secp256k1-sys).
+    # When a crate's build.rs uses cc-rs to compile C source files for thumbv7m-none-eabi,
+    # it needs arm-none-eabi-gcc because system gcc doesn't support ARM target flags.
+    # Pure Rust crates only need rustc and rust-lld (already included with Rust).
+    - name: Install ARM cross-compiler
       shell: bash
       run: |
-        sudo apt-get update -y
-        sudo apt-get install -y gcc-arm-none-eabi
+        # --no-install-recommends reduces install size by skipping newlib.
+        sudo apt-get install -y --no-install-recommends gcc-arm-none-eabi
         echo "CC_thumbv7m_none_eabi=arm-none-eabi-gcc" >> $GITHUB_ENV

--- a/cargo-rbmt/README.md
+++ b/cargo-rbmt/README.md
@@ -8,6 +8,7 @@ Maintainer tools for Rust-based projects in the Bitcoin domain. Built with [xshe
 - [Configuration](#configuration)
 - [Lint](#lint)
 - [Test](#test)
+  - [no_std](#no_std)
 - [Integration](#integration)
 - [Prerelease](#prerelease)
 - [Lock Files](#lock-files)
@@ -80,6 +81,10 @@ exact_features = [
 # Example: ["serde", "rand"] tests: no-std+serde, no-std+rand, no-std+serde+rand
 features_with_no_std = ["serde", "rand"]
 ```
+
+### no_std
+
+When a package declares `#![no_std]` in its library source, `cargo-rbmt test` automatically performs an additional verification step on the `thumbv7m-none-eabi` target to try and detect unintentional std library usage.
 
 ## Integration
 

--- a/cargo-rbmt/src/test.rs
+++ b/cargo-rbmt/src/test.rs
@@ -367,8 +367,8 @@ fn do_no_std_check(sh: &Shell, package_dir: &Path) -> Result<(), Box<dyn std::er
         return Ok(());
     }
 
-    quiet_println(&format!("Detected no-std package, checking with target: {}", NO_STD_TARGET));
-    quiet_cmd!(sh, "cargo check --target {NO_STD_TARGET} --no-default-features").run()?;
-    quiet_println("no-std check passed!");
+    quiet_println(&format!("Detected no-std package, building for target: {}", NO_STD_TARGET));
+    quiet_cmd!(sh, "cargo build --target {NO_STD_TARGET} --no-default-features").run()?;
+    quiet_println("no-std build passed!");
     Ok(())
 }


### PR DESCRIPTION
Running `cargo build` is a little higher bar than `cargo check` with no extra requirements, and appears to be the ecosystem standard. Tried to slim up the install action a bit for no-std stuff as well since have seen the install sometimes hang for awhile in practice.