### PR TITLE
cargo-rbmt: move api files into package

### DIFF
--- a/cargo-rbmt/src/api.rs
+++ b/cargo-rbmt/src/api.rs
@@ -31,7 +31,7 @@ impl Drop for GitSwitchGuard<'_> {
     }
 }
 
-/// Directory where API files are stored, relative to workspace root.
+/// Directory where API files are stored, relative to each package directory.
 const API_DIR: &str = "api";
 
 /// RUSTDOCFLAGS to allow broken intra-doc links during API checking.
@@ -124,8 +124,8 @@ impl FeatureConfig {
 /// Run the API check task.
 ///
 /// This command checks for changes to the public API of workspace packages by generating
-/// API files using the `public-api` library and comparing them with committed versions in the
-/// `api/` directory.
+/// API files using the `public-api` library and comparing them with committed versions in each
+/// package's own `api/` directory.
 ///
 /// Always checks that features are additive and API files match git state.
 /// When a baseline ref is given or configured, also performs semver
@@ -205,6 +205,8 @@ fn check_apis(
     package_info: &[(String, PathBuf)],
     baseline: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let mut api_dirs: Vec<PathBuf> = Vec::new();
+
     for (package_name, package_dir) in package_info {
         let api_config = ApiConfig::load(package_dir)?;
 
@@ -212,12 +214,13 @@ fn check_apis(
             continue;
         }
 
+        check_api_excluded(package_dir, package_name)?;
         let mut apis = get_package_apis(sh, package_name, package_dir)?;
 
-        // Write API files.
-        let workspace_root = sh.current_dir();
-        let package_api_dir = workspace_root.join(API_DIR).join(package_name);
+        // Write API files into the package's own api/ directory.
+        let package_api_dir = package_dir.join(API_DIR);
         fs::create_dir_all(&package_api_dir)?;
+        api_dirs.push(package_api_dir.clone());
 
         for (config, public_api) in &apis {
             let output_file = package_api_dir.join(config.filename());
@@ -259,16 +262,38 @@ fn check_apis(
         }
     }
 
-    let status_output = quiet_cmd!(sh, "git status --porcelain {API_DIR}").read()?;
-    if !status_output.trim().is_empty() {
-        // Show the diff for context.
-        quiet_cmd!(sh, "git diff --color=always {API_DIR}").run()?;
+    for api_dir in &api_dirs {
+        let status_output = quiet_cmd!(sh, "git status --porcelain {api_dir}").read()?;
+        if !status_output.trim().is_empty() {
+            // Show the diff for context.
+            quiet_cmd!(sh, "git diff --color=always {api_dir}").run()?;
 
-        eprintln!();
-        return Err(
-            "You have introduced changes to the public API, commit the changes to api/ currently in your working directory"
-                .into(),
-        );
+            eprintln!();
+            return Err(format!(
+                "You have introduced changes to the public API, commit the changes to {} currently in your working directory",
+                api_dir.display()
+            ).into());
+        }
+    }
+
+    Ok(())
+}
+
+/// Check that the package's manifest excludes the `api/` directory from publishing.
+fn check_api_excluded(
+    package_dir: &Path,
+    package_name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let manifest = environment::Manifest::read(package_dir)?;
+
+    if !manifest.exclude.iter().any(|e| e.starts_with("api")) {
+        return Err(format!(
+            "Package '{}' has an api/ directory but does not exclude it from publishing. \
+             Add \"api\" to the `exclude` list in {}/Cargo.toml.",
+            package_name,
+            package_dir.display(),
+        )
+        .into());
     }
 
     Ok(())

--- a/cargo-rbmt/src/environment.rs
+++ b/cargo-rbmt/src/environment.rs
@@ -1,5 +1,5 @@
-use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::{env, fs};
 
 use xshell::Shell;
 
@@ -163,4 +163,35 @@ pub fn get_target_dir(sh: &Shell) -> Result<String, Box<dyn std::error::Error>> 
         json["target_directory"].as_str().ok_or("Missing target_directory in cargo metadata")?;
 
     Ok(target_dir.to_string())
+}
+
+/// A minimal representation of a package manifest (`Cargo.toml`).
+///
+/// Only fields not available via `cargo metadata` are included here. Prefer
+/// `cargo metadata` for all other package information since it is the stable,
+/// supported interface for querying package data.
+pub struct Manifest {
+    /// The `exclude` field from `[package]`, listing paths excluded from publishing.
+    pub exclude: Vec<String>,
+}
+
+impl Manifest {
+    /// Read and parse the `Cargo.toml` in the given package directory.
+    pub fn read(package_dir: &Path) -> Result<Self, Box<dyn std::error::Error>> {
+        #[derive(serde::Deserialize)]
+        struct CargoToml {
+            package: CargoPackage,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct CargoPackage {
+            #[serde(default)]
+            exclude: Vec<String>,
+        }
+
+        let contents = fs::read_to_string(package_dir.join("Cargo.toml"))?;
+        let cargo_toml: CargoToml = toml::from_str(&contents)?;
+
+        Ok(Self { exclude: cargo_toml.package.exclude })
+    }
 }


### PR DESCRIPTION
The original push for this change was to address how api files were namespaced under the top level api/ dir, [should it be with the package manifest name or match the package directory](https://github.com/rust-bitcoin/rust-bitcoin-maintainer-tools/discussions). This side steps the issue by just putting the api/ dir under the package directory. API files are now broken up by package.

Probably more helpfully though, this change allows a workspace and a single package repo (e.g. rust-psbt) to be treated the same, simplify configs and rbmt. 

A possible downside to pushing the api files into the package directory is that they then get published by default. So a quick check is added to make sure a package manifest excludes the api/ dir.