### PR TITLE
cargo-rbmt: switch toolchain from positional arg to flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
           rbmt-version: ${{ github.sha }}
 
       - name: Run tests (${{ matrix.toolchain }}, ${{ matrix.lock-file }} lock)
-        run: cargo rbmt --lock-file ${{ matrix.lock-file }} test ${{ matrix.toolchain }}
+        run: cargo rbmt --lock-file ${{ matrix.lock-file }} test --toolchain ${{ matrix.toolchain }}

--- a/cargo-rbmt/README.md
+++ b/cargo-rbmt/README.md
@@ -173,8 +173,8 @@ The command prints `export` statements to stdout and all other output to stderr,
 eval "$(cargo rbmt toolchains)"
 
 cargo +$RBMT_NIGHTLY rbmt lint
-cargo +$RBMT_STABLE rbmt test stable
-cargo +$RBMT_MSRV rbmt test msrv
+cargo +$RBMT_STABLE rbmt test
+cargo +$RBMT_MSRV rbmt test --toolchain msrv
 ```
 
 The `--update-nightly` and `--update-stable` flags each install the corresponding floating toolchain, query its resolved version from `rustc`, and write the result to the appropriate version file before proceeding with the normal install and export.
@@ -223,7 +223,7 @@ steps:
   - uses: actions/checkout@v6
   - uses: rust-bitcoin/rust-bitcoin-maintainer-tools/.github/actions/setup-rbmt@master
     id: setup
-  - run: cargo +${{ steps.setup.outputs.stable }} rbmt test stable
+  - run: cargo +${{ steps.setup.outputs.stable }} rbmt test
 ```
 
 See the [action](../.github/actions/setup-rbmt/action.yml) for more details.

--- a/cargo-rbmt/src/main.rs
+++ b/cargo-rbmt/src/main.rs
@@ -53,7 +53,7 @@ enum Commands {
     /// Run tests with specified toolchain.
     Test {
         /// Toolchain to use: stable, nightly, or msrv.
-        #[arg(value_enum)]
+        #[arg(long, value_enum, default_value_t = Toolchain::Stable)]
         toolchain: Toolchain,
         /// Disable debug assertions in compiled code.
         #[arg(long)]


### PR DESCRIPTION
Little more ergonomic given stable is the usual.