### PR TITLE
cargo-rbmt: add tools command

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -17,6 +17,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
+ "toml_edit 0.22.7",
  "xshell",
 ]
 
@@ -184,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
 ]
@@ -231,14 +232,14 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.20.0",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
@@ -253,7 +254,20 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.0",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.0",
 ]
 
 [[package]]
@@ -267,6 +281,15 @@ name = "winnow"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1dbce9e90e5404c5a52ed82b1d13fc8cfbdad85033b6f57546ffd1265f8451"
 dependencies = [
  "memchr",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -17,6 +17,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
+ "toml_edit",
  "xshell",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
+ "toml_edit",
  "xshell",
 ]
 

--- a/cargo-rbmt/Cargo.toml
+++ b/cargo-rbmt/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "4.5", features = ["derive", "std", "help"], default-features
 serde = { version = "1.0.186", features = ["derive"] }
 serde_json = "1.0.104"
 toml = "0.8"
+toml_edit = { version = "0.22.7", features = ["serde"] }
 public-api = { version = "0.50", default-features = false }
 
 [lints]

--- a/cargo-rbmt/README.md
+++ b/cargo-rbmt/README.md
@@ -15,6 +15,7 @@ Maintainer tools for Rust-based projects in the Bitcoin domain. Built with [xshe
 - [Lock Files](#lock-files)
 - [API](#api)
 - [Toolchains](#toolchains)
+- [Tools](#tools)
 - [Workspace Integration](#workspace-integration)
   - [1. Install on system](#1-install-on-system)
   - [2. Add as a dev-dependency](#2-add-as-a-dev-dependency)
@@ -181,6 +182,36 @@ cargo +$RBMT_MSRV rbmt test --toolchain msrv
 ```
 
 The `--update-nightly` and `--update-stable` flags each install the corresponding floating toolchain, query its resolved version from `rustc`, and write the result to the appropriate version file before proceeding with the normal install and export.
+
+## Tools
+
+The `tools` command installs external cargo tools whose versions are pinned in the root `Cargo.toml`. The preferred location is `[workspace.metadata.rbmt.tools]`:
+
+```toml
+[workspace.metadata.rbmt.tools]
+cargo-semver-checks = "0.46.0"
+cargo-public-api = "0.50.1"
+```
+
+For single-package repos with no explicit `[workspace]` table, `[package.metadata.rbmt.tools]` is supported as a fallback.
+
+```bash
+# Install all tools at their pinned versions.
+cargo rbmt tools
+
+# Install only a specific tool.
+cargo rbmt tools cargo-semver-checks
+
+# Install each tool at its latest version and update the pins in Cargo.toml.
+cargo rbmt tools --update
+
+# Update only a specific tool.
+cargo rbmt tools --update cargo-public-api
+```
+
+The `--update` flag installs each tool without a version constraint, then reads the resolved version back from `cargo install --list` and writes it into `Cargo.toml`. The resulting diff can be reviewed and committed as a deliberate version bump.
+
+> **Note:** Tools are installed via `cargo install`. Installing or updating a tool overwrites any previously installed version of that binary system-wide. If you rely on a specific version of a tool outside of this workflow, be aware that running `cargo rbmt tools` will replace it with the pinned version.
 
 ## Workspace Integration
 

--- a/cargo-rbmt/src/environment.rs
+++ b/cargo-rbmt/src/environment.rs
@@ -144,10 +144,13 @@ pub fn get_packages(
 
 /// Get the workspace root directory from metadata.
 ///
-/// This is the directory containing the top-level `Cargo.toml` (the one with
-/// `[workspace]`). It is the authoritative location for workspace-level files
-/// such as `nightly-version` and `stable-version`, regardless of where the
-/// shell's current directory happens to be.
+/// This is the directory containing the top-level `Cargo.toml`. It is the
+/// authoritative location for workspace-level files, regardless of where
+/// the shell's current directory happens to be.
+///
+/// For single-package repositories with no explicit `[workspace]` table, Cargo
+/// creates an implicit workspace and `workspace_root` resolves to the package
+/// directory itself.
 pub fn get_workspace_root(sh: &Shell) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let metadata = quiet_cmd!(sh, "cargo metadata --no-deps --format-version 1").read()?;
     let json: serde_json::Value = serde_json::from_str(&metadata)?;

--- a/cargo-rbmt/src/main.rs
+++ b/cargo-rbmt/src/main.rs
@@ -10,6 +10,7 @@ mod prerelease;
 mod test;
 mod toolchain;
 mod toolchains;
+mod tools;
 
 use std::process;
 
@@ -91,6 +92,14 @@ enum Commands {
         #[arg(long)]
         msrv: bool,
     },
+    /// Install tools pinned in [workspace.metadata.rbmt.tools].
+    Tools {
+        /// Install each tool at its latest version and update the pin in Cargo.toml.
+        #[arg(long)]
+        update: bool,
+        /// Only operate on these tools (default: all tools in the manifest).
+        tools: Vec<String>,
+    },
 }
 
 fn main() {
@@ -106,11 +115,14 @@ fn main() {
     let sh = Shell::new().unwrap();
     configure_log_level(&sh);
 
-    // Restore the specified lock file before running any command (except commands that don't
-    // compile the workspace: Fmt, Lock, Integration, Toolchains).
+    // Restore the specified lock file before running commands which require lock files.
     if !matches!(
         cli.command,
-        Commands::Fmt { .. } | Commands::Lock | Commands::Integration | Commands::Toolchains { .. }
+        Commands::Fmt { .. }
+            | Commands::Lock
+            | Commands::Integration
+            | Commands::Toolchains { .. }
+            | Commands::Tools { .. }
     ) {
         if let Err(e) = cli.lock_file.restore(&sh) {
             eprintln!("Error restoring lock file: {}", e);
@@ -182,6 +194,11 @@ fn main() {
         Commands::Toolchains { update_nightly, update_stable, msrv } =>
             if let Err(e) = toolchains::run(&sh, update_nightly, update_stable, msrv) {
                 eprintln!("Error setting up toolchains: {}", e);
+                process::exit(1);
+            },
+        Commands::Tools { update, tools } =>
+            if let Err(e) = tools::run(&sh, update, &tools) {
+                eprintln!("Error managing tools: {}", e);
                 process::exit(1);
             },
     }

--- a/cargo-rbmt/src/tools.rs
+++ b/cargo-rbmt/src/tools.rs
@@ -1,0 +1,217 @@
+//! Management of pinned external cargo tools.
+//!
+//! Cargo currently has no native mechanism for pinning the versions of tools
+//! installed via `cargo install`. The `Cargo.lock` file only covers
+//! dependencies of packages in the current workspace, not standalone binaries.
+//!
+//! ## Configuration
+//!
+//! Tool versions are stored in the root `Cargo.toml`. The preferred location is
+//! `[workspace.metadata.rbmt.tools]`, which works for multi-crate workspaces
+//! and single-package repos with an explicit `[workspace]` table.
+//!
+//! ```toml
+//! [workspace.metadata.rbmt.tools]
+//! cargo-semver-checks = "0.46.0"
+//! ```
+//!
+//! For single-package repos with no explicit `[workspace]` table,
+//! `[package.metadata.rbmt.tools]` is used as a fallback.
+//!
+//! ## Why `[workspace.metadata]`?
+//!
+//! Cargo reserves `[package.metadata]` and `[workspace.metadata]` as
+//! explicitly supported extension points for third-party tooling. Cargo itself
+//! ignores any keys nested under these tables, so they will never clash with a
+//! future built-in Cargo field, and old Cargo versions silently skip them
+//! without error. `[workspace.metadata]` was stabilised in Cargo 1.46. The `rbmt`
+//! sub-key further namespaces the configuration to avoid collisions with other tools.
+
+use std::collections::BTreeMap;
+
+use xshell::Shell;
+
+use crate::environment::{get_workspace_root, quiet_println};
+use crate::quiet_cmd;
+
+/// Where the tool pins were found in the root `Cargo.toml`.
+///
+/// `[workspace.metadata.rbmt.tools]` is preferred and works for both
+/// multi-crate workspaces and single-package repos that have an explicit
+/// `[workspace]` table. `[package.metadata.rbmt.tools]` is the fallback for
+/// single-package repos with no explicit `[workspace]` table.
+enum ToolsLocation {
+    Workspace,
+    Package,
+}
+
+/// The pinned tool versions and where they were found.
+struct Tools {
+    map: BTreeMap<String, String>,
+    location: ToolsLocation,
+}
+
+impl Tools {
+    /// Returns the TOML key path for error messages.
+    fn table_name(&self) -> &'static str {
+        match self.location {
+            ToolsLocation::Workspace => "[workspace.metadata.rbmt.tools]",
+            ToolsLocation::Package => "[package.metadata.rbmt.tools]",
+        }
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct CargoToml {
+    #[serde(default)]
+    workspace: WorkspaceSection,
+    #[serde(default)]
+    package: PackageSection,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct WorkspaceSection {
+    #[serde(default)]
+    metadata: RbmtMetadataWrapper,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct PackageSection {
+    #[serde(default)]
+    metadata: RbmtMetadataWrapper,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct RbmtMetadataWrapper {
+    rbmt: Option<RbmtMetadata>,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct RbmtMetadata {
+    tools: Option<BTreeMap<String, String>>,
+}
+
+/// Read tool pins from the root `Cargo.toml`.
+///
+/// Tries `[workspace.metadata.rbmt.tools]` first, then falls back to
+/// `[package.metadata.rbmt.tools]`. Returns `None` if neither table is present.
+fn read_tools(sh: &Shell) -> Result<Option<Tools>, Box<dyn std::error::Error>> {
+    let root = get_workspace_root(sh)?;
+    let contents = std::fs::read_to_string(root.join("Cargo.toml"))?;
+    let cargo_toml: CargoToml = toml::from_str(&contents)?;
+
+    if let Some(map) = cargo_toml.workspace.metadata.rbmt.and_then(|r| r.tools) {
+        return Ok(Some(Tools { map, location: ToolsLocation::Workspace }));
+    }
+
+    if let Some(map) = cargo_toml.package.metadata.rbmt.and_then(|r| r.tools) {
+        return Ok(Some(Tools { map, location: ToolsLocation::Package }));
+    }
+
+    Ok(None)
+}
+
+/// Write an updated version for a single tool into the appropriate metadata table.
+fn write_tool_version(
+    sh: &Shell,
+    name: &str,
+    version: &str,
+    location: &ToolsLocation,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let root = get_workspace_root(sh)?;
+    let path = root.join("Cargo.toml");
+    let contents = std::fs::read_to_string(&path)?;
+
+    let mut doc: toml_edit::DocumentMut = contents.parse()?;
+    let table = match location {
+        ToolsLocation::Workspace => &mut doc["workspace"]["metadata"]["rbmt"]["tools"],
+        ToolsLocation::Package => &mut doc["package"]["metadata"]["rbmt"]["tools"],
+    };
+    table[name] = toml_edit::value(version);
+    std::fs::write(&path, doc.to_string())?;
+
+    Ok(())
+}
+
+/// Read the installed version of a crate from `cargo install --list` output.
+///
+/// ```text
+/// crate-name v1.2.3:
+///     binary-name
+/// ```
+///
+/// Returns `None` if the crate is not currently installed.
+fn installed_version(
+    sh: &Shell,
+    crate_name: &str,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let output = quiet_cmd!(sh, "cargo install --list").read()?;
+
+    let prefix = format!("{} v", crate_name);
+    let version = output
+        .lines()
+        .find(|line| line.starts_with(&prefix))
+        .and_then(|line| line.strip_prefix(&prefix))
+        .and_then(|rest| rest.split([' ', ':']).next())
+        .map(str::to_string);
+
+    Ok(version)
+}
+
+/// Install a single tool at a pinned version using `cargo install`.
+fn install_tool(sh: &Shell, name: &str, version: &str) -> Result<(), Box<dyn std::error::Error>> {
+    quiet_println(&format!("Installing {}@{}", name, version));
+    quiet_cmd!(sh, "cargo install {name} --version {version} --locked").run()?;
+    Ok(())
+}
+
+/// Install a single tool at the latest version and return the resolved version.
+fn install_tool_latest(sh: &Shell, name: &str) -> Result<String, Box<dyn std::error::Error>> {
+    quiet_println(&format!("Installing {} (latest)", name));
+    quiet_cmd!(sh, "cargo install {name}").run()?;
+
+    installed_version(sh, name)?
+        .ok_or_else(|| format!("{} not found in `cargo install --list` after install", name).into())
+}
+
+/// Install all tools pinned in the root `Cargo.toml`.
+///
+/// When `update` is true, each tool is installed at its latest version and the
+/// pin in `Cargo.toml` is updated in place to match. When false, each tool is
+/// installed at its pinned version.
+///
+/// When `filter` is non-empty, only the named tools are operated on. Unknown
+/// tool names in the filter are treated as an error.
+pub fn run(sh: &Shell, update: bool, filter: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(mut tools) = read_tools(sh)? else {
+        eprintln!(
+            "No tools found in [workspace.metadata.rbmt.tools] or [package.metadata.rbmt.tools]."
+        );
+        return Ok(());
+    };
+
+    if !filter.is_empty() {
+        for name in filter {
+            if !tools.map.contains_key(name) {
+                return Err(format!("'{}' is not in {}", name, tools.table_name()).into());
+            }
+        }
+        tools.map.retain(|name, _| filter.contains(name));
+    }
+
+    for (name, pinned_version) in &tools.map {
+        if update {
+            let latest = install_tool_latest(sh, name)?;
+            if &latest == pinned_version {
+                quiet_println(&format!("{} is already at latest ({})", name, pinned_version));
+            } else {
+                quiet_println(&format!("Updated {} {} -> {}", name, pinned_version, latest));
+                write_tool_version(sh, name, &latest, &tools.location)?;
+            }
+        } else {
+            install_tool(sh, name, pinned_version)?;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Over in rust-bitcoin, we are [considering managing another CI tool version (zizmor) with `cargo install`](https://github.com/rust-bitcoin/rust-bitcoin/pull/5832). That got me thinking that it might be nice extend cargo-rbmt to help manage and install these tools.

This new `tools` command still just uses cargo under the hood, wrapping some `cargo install` commands. It makes use of the [`workspace.metadata.*`](https://doc.rust-lang.org/cargo/reference/workspaces.html?highlight=workspace#the-metadata-table) namespace to store the tool versions.