### PR TITLE
cargo-rbmt: use full pkgid to refer to workspace packages

### DIFF
--- a/cargo-rbmt/src/api.rs
+++ b/cargo-rbmt/src/api.rs
@@ -177,18 +177,18 @@ fn check_apis(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut api_dirs: Vec<PathBuf> = Vec::new();
 
-    for (package_name, package_dir) in package_info {
-        let api_config = ApiConfig::load(package_dir)?;
+    for package in package_info {
+        let api_config = ApiConfig::load(&package.dir)?;
 
         if !api_config.enabled {
             continue;
         }
 
-        check_api_excluded(package_dir, package_name)?;
-        let mut apis = get_package_apis(sh, package_name, package_dir)?;
+        check_api_excluded(&package.dir, &package.name)?;
+        let mut apis = get_package_apis(sh, &package.name, &package.dir)?;
 
         // Write API files into the package's own api/ directory.
-        let package_api_dir = package_dir.join(API_DIR);
+        let package_api_dir = package.dir.join(API_DIR);
         fs::create_dir_all(&package_api_dir)?;
         api_dirs.push(package_api_dir.clone());
 
@@ -206,7 +206,7 @@ fn check_apis(
         let diff = public_api::diff::PublicApiDiff::between(no_features, all_features);
 
         if !diff.removed.is_empty() || !diff.changed.is_empty() {
-            eprintln!("Non-additive features detected in {}:", package_name);
+            eprintln!("Non-additive features detected in {}:", package.name);
 
             if !diff.removed.is_empty() {
                 eprintln!("  Items removed when enabling features:");
@@ -227,7 +227,7 @@ fn check_apis(
         }
 
         if let Some(baseline) = baseline {
-            check_semver(sh, package_name, package_dir, baseline)?;
+            check_semver(sh, &package.name, &package.dir, baseline)?;
         }
     }
 

--- a/cargo-rbmt/src/bench.rs
+++ b/cargo-rbmt/src/bench.rs
@@ -12,11 +12,11 @@ pub fn run(sh: &Shell, packages: &[Package]) -> Result<(), Box<dyn std::error::E
 
     quiet_println(&format!("Running bench tests for {} crates", packages.len()));
 
-    for (_package_name, package_dir) in packages {
-        quiet_println(&format!("Running bench tests in: {}", package_dir.display()));
+    for package in packages {
+        quiet_println(&format!("Running bench tests in: {}", package.dir.display()));
 
         // Use pushd pattern to change and restore directory.
-        let _dir = sh.push_dir(package_dir);
+        let _dir = sh.push_dir(&package.dir);
 
         quiet_cmd!(sh, "cargo --locked bench").env("RUSTFLAGS", "--cfg=bench").run()?;
     }

--- a/cargo-rbmt/src/docs.rs
+++ b/cargo-rbmt/src/docs.rs
@@ -16,8 +16,8 @@ pub fn run(sh: &Shell, packages: &[Package]) -> Result<(), Box<dyn std::error::E
     let mut cmd = quiet_cmd!(sh, "cargo --locked doc --all-features --no-deps");
 
     // Add package filters if specified.
-    for (name, _) in packages {
-        cmd = cmd.args(&["-p", name]);
+    for package in packages {
+        cmd = cmd.args(&["-p", &package.id]);
     }
 
     cmd.env("RUSTDOCFLAGS", "-D warnings").run()?;
@@ -35,8 +35,8 @@ pub fn run_docsrs(sh: &Shell, packages: &[Package]) -> Result<(), Box<dyn std::e
     let mut cmd = quiet_cmd!(sh, "cargo --locked doc --all-features --no-deps");
 
     // Add package filters if specified.
-    for (name, _) in packages {
-        cmd = cmd.args(&["-p", name]);
+    for package in packages {
+        cmd = cmd.args(&["-p", &package.id]);
     }
 
     cmd.env("RUSTDOCFLAGS", "--cfg docsrs -D warnings -D rustdoc::broken-intra-doc-links").run()?;

--- a/cargo-rbmt/src/environment.rs
+++ b/cargo-rbmt/src/environment.rs
@@ -8,8 +8,16 @@ use xshell::Shell;
 /// Any other value (or unset) defaults to verbose mode.
 const LOG_LEVEL_ENV_VAR: &str = "RBMT_LOG_LEVEL";
 
-/// A workspace package: its manifest name and directory path.
-pub type Package = (String, PathBuf);
+/// A workspace package: its manifest name, directory path, and unique identifier.
+#[derive(Clone, Debug)]
+pub struct Package {
+    /// The package name from the manifest.
+    pub name: String,
+    /// The directory path where the package is located.
+    pub dir: PathBuf,
+    /// The unique package identifier.
+    pub id: String,
+}
 
 /// Check if we're in quiet mode via environment variable.
 pub fn is_quiet_mode() -> bool { env::var(LOG_LEVEL_ENV_VAR).is_ok_and(|v| v == "quiet") }
@@ -67,13 +75,13 @@ pub fn get_packages(
         .ok_or("Missing 'packages' field in cargo metadata")?
         .iter()
         .filter_map(|package| {
-            let package_name = package["name"].as_str()?;
-            let manifest_path = package["manifest_path"].as_str()?;
-            // Extract directory path from the manifest path,
-            // e.g., "/path/to/repo/releases/Cargo.toml" -> "/path/to/repo/releases".
-            let dir_path = manifest_path.trim_end_matches("/Cargo.toml");
-
-            Some((package_name.to_owned(), PathBuf::from(dir_path)))
+            Some(Package {
+                name: package["name"].as_str()?.to_string(),
+                dir: PathBuf::from(
+                    package["manifest_path"].as_str()?.trim_end_matches("/Cargo.toml"),
+                ),
+                id: package["id"].as_str()?.to_string(),
+            })
         })
         .collect();
 
@@ -89,7 +97,7 @@ pub fn get_packages(
 
     for requested in packages {
         // Exact manifest name match.
-        if all_packages.iter().any(|(name, _)| name == requested) {
+        if all_packages.iter().any(|pkg| &pkg.name == requested) {
             resolved_names.push(requested.clone());
             continue;
         }
@@ -97,8 +105,8 @@ pub fn get_packages(
         // Fall back to directory basename match.
         let dir_matches: Vec<&Package> = all_packages
             .iter()
-            .filter(|(_, dir)| {
-                dir.file_name().and_then(|n| n.to_str()).is_some_and(|n| n == requested)
+            .filter(|pkg| {
+                pkg.dir.file_name().and_then(|n| n.to_str()).is_some_and(|n| n == requested)
             })
             .collect();
 
@@ -107,8 +115,7 @@ pub fn get_packages(
                 errors.push(format!("Package not found in workspace: '{}'", requested));
             }
             1 => {
-                let (name, _) = dir_matches[0];
-                resolved_names.push(name.clone());
+                resolved_names.push(dir_matches[0].name.clone());
             }
             _ => {
                 errors.push(format!(
@@ -123,8 +130,8 @@ pub fn get_packages(
         let mut error_msg = errors.join("\n\n");
 
         error_msg.push_str("\n\nAvailable packages (manifest name / directory):");
-        for (name, dir) in &all_packages {
-            error_msg.push_str(&format!("\n  - {} ({})", name, dir.display()));
+        for pkg in &all_packages {
+            error_msg.push_str(&format!("\n  - {} ({})", pkg.name, pkg.dir.display()));
         }
 
         return Err(error_msg.into());
@@ -133,7 +140,7 @@ pub fn get_packages(
     // Filter to only resolved packages.
     let package_info: Vec<Package> = all_packages
         .into_iter()
-        .filter(|(name, _)| resolved_names.iter().any(|r| r == name))
+        .filter(|pkg| resolved_names.iter().any(|r| r == &pkg.name))
         .collect();
 
     Ok(package_info)
@@ -174,7 +181,7 @@ pub fn get_target_dir(sh: &Shell) -> Result<String, Box<dyn std::error::Error>> 
 /// are included automatically.
 pub fn discover_features(
     sh: &Shell,
-    (_, package_dir): &Package,
+    package: &Package,
 ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     let metadata = quiet_cmd!(sh, "cargo metadata --format-version 1 --no-deps").read()?;
     let json: serde_json::Value = serde_json::from_str(&metadata)?;
@@ -183,13 +190,13 @@ pub fn discover_features(
         json["packages"].as_array().ok_or("Missing 'packages' field in cargo metadata")?;
 
     // Match by manifest path so this works regardless of the shell's cwd.
-    let manifest_path = package_dir.join("Cargo.toml");
-    let package = packages
+    let manifest_path = package.dir.join("Cargo.toml");
+    let pkg = packages
         .iter()
         .find(|p| p["manifest_path"].as_str().is_some_and(|path| Path::new(path) == manifest_path))
-        .ok_or_else(|| format!("Package not found in cargo metadata: {}", package_dir.display()))?;
+        .ok_or_else(|| format!("Package not found in cargo metadata: {}", package.dir.display()))?;
 
-    let mut features: Vec<String> = package["features"]
+    let mut features: Vec<String> = pkg["features"]
         .as_object()
         .map(|f| f.keys().filter(|k| *k != "default").cloned().collect())
         .unwrap_or_default();

--- a/cargo-rbmt/src/fmt.rs
+++ b/cargo-rbmt/src/fmt.rs
@@ -21,8 +21,8 @@ pub fn run(sh: &Shell, check: bool, packages: &[Package]) -> Result<(), Box<dyn 
     if packages.is_empty() {
         cmd = cmd.arg("--all");
     } else {
-        for (name, _) in packages {
-            cmd = cmd.args(&["-p", name]);
+        for package in packages {
+            cmd = cmd.args(&["-p", &package.name]);
         }
     }
 

--- a/cargo-rbmt/src/integration.rs
+++ b/cargo-rbmt/src/integration.rs
@@ -1,11 +1,11 @@
 //! Integration test tasks for packages with bitcoind-tests or similar test packages.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use serde::Deserialize;
 use xshell::Shell;
 
-use crate::environment::{discover_features, quiet_println, PackageManifest, Package};
+use crate::environment::{discover_features, quiet_println, Package, PackageManifest};
 use crate::quiet_cmd;
 
 /// Integration-specific configuration, read from `[package.metadata.rbmt.integration]` in `Cargo.toml`.
@@ -38,11 +38,22 @@ impl IntegrationConfig {
             return Ok(Self::default());
         }
         let contents = std::fs::read_to_string(&path)?;
-        Ok(toml::from_str::<PackageManifest<RbmtTable>>(&contents)?.package.metadata.rbmt.integration)
+        Ok(toml::from_str::<PackageManifest<RbmtTable>>(&contents)?
+            .package
+            .metadata
+            .rbmt
+            .integration)
     }
 
     /// Get the package name (defaults to "bitcoind-tests").
     fn package_name(&self) -> &str { self.package.as_deref().unwrap_or("bitcoind-tests") }
+}
+
+/// Get the package ID by running `cargo pkgid` in the given directory.
+fn get_package_id(sh: &Shell, dir: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    let _dir = sh.push_dir(dir);
+    let id = quiet_cmd!(sh, "cargo pkgid").read()?;
+    Ok(id.trim().to_string())
 }
 
 /// Run integration tests for all crates with integration test packages.
@@ -53,9 +64,9 @@ impl IntegrationConfig {
 pub fn run(sh: &Shell, packages: &[Package]) -> Result<(), Box<dyn std::error::Error>> {
     quiet_println(&format!("Looking for integration tests in {} crate(s)", packages.len()));
 
-    for (package_name, package_dir) in packages {
-        let config = IntegrationConfig::load(Path::new(package_dir))?;
-        let integration_dir = PathBuf::from(package_dir).join(config.package_name());
+    for package in packages {
+        let config = IntegrationConfig::load(Path::new(&package.dir))?;
+        let integration_dir = package.dir.join(config.package_name());
 
         if !integration_dir.exists() {
             continue;
@@ -65,11 +76,15 @@ pub fn run(sh: &Shell, packages: &[Package]) -> Result<(), Box<dyn std::error::E
             continue;
         }
 
-        quiet_println(&format!("Running integration tests for {}", package_name));
+        quiet_println(&format!("Running integration tests for {}", package.name));
 
         let _dir = sh.push_dir(&integration_dir);
 
-        let integration_package = (config.package_name().to_owned(), integration_dir.clone());
+        let integration_package = Package {
+            name: config.package_name().to_string(),
+            dir: integration_dir.clone(),
+            id: get_package_id(sh, &integration_dir)?,
+        };
         let available_versions = discover_features(sh, &integration_package)?;
         if available_versions.is_empty() {
             quiet_println("  No version features found in Cargo.toml");

--- a/cargo-rbmt/src/lint.rs
+++ b/cargo-rbmt/src/lint.rs
@@ -78,12 +78,12 @@ fn lint_workspace(sh: &Shell) -> Result<(), Box<dyn std::error::Error>> {
 fn lint_packages(sh: &Shell, packages: &[Package]) -> Result<(), Box<dyn std::error::Error>> {
     quiet_println("Running package-specific lints...");
 
-    let package_names: Vec<_> = packages.iter().map(|(name, _)| name.as_str()).collect();
+    let package_names: Vec<_> = packages.iter().map(|p| p.name.as_str()).collect();
     quiet_println(&format!("Found crates: {}", package_names.join(", ")));
 
-    for (_package_name, package_dir) in packages {
+    for package in packages {
         // Returns a RAII guard which reverts the working directory to the old value when dropped.
-        let _old_dir = sh.push_dir(package_dir);
+        let _old_dir = sh.push_dir(&package.dir);
 
         // Run clippy without default features.
         quiet_cmd!(sh, "cargo --locked clippy --all-targets --no-default-features --keep-going")
@@ -115,11 +115,11 @@ fn check_duplicate_deps(sh: &Shell, packages: &[Package]) -> Result<(), Box<dyn 
 
     let mut found_duplicates = false;
 
-    for (package_name, package_dir) in packages {
-        let config = LintConfig::load(package_dir)?;
+    for package in packages {
+        let config = LintConfig::load(&package.dir)?;
 
         // Returns a RAII guard which reverts the working directory to the old value when dropped.
-        let _old_dir = sh.push_dir(package_dir);
+        let _old_dir = sh.push_dir(&package.dir);
 
         // Run cargo tree to find duplicates for this package, exclude dev dependencies
         // since they are not exposed to downstream consumers.
@@ -132,13 +132,13 @@ fn check_duplicate_deps(sh: &Shell, packages: &[Package]) -> Result<(), Box<dyn 
 
         let tree = DuplicateTree::parse(
             &output,
-            &[package_name.as_str()].into(),
+            &[package.name.as_str()].into(),
             &config.allowed_duplicates,
         );
         if !tree.duplicates().is_empty() {
             found_duplicates = true;
             eprintln!("{}", output);
-            eprintln!("Error: Found duplicate dependencies in package '{}'!", package_name);
+            eprintln!("Error: Found duplicate dependencies in package '{}'!", package.name);
             for (name, versions) in tree.duplicates() {
                 for version in versions.keys() {
                     eprintln!("  {} {}", name, version);
@@ -183,7 +183,7 @@ fn check_cross_package_duplicate_deps(sh: &Shell) -> Result<(), Box<dyn std::err
 
     quiet_println("Checking for cross-package duplicate dependencies...");
 
-    let package_names: HashSet<&str> = package_info.iter().map(|(name, _)| name.as_str()).collect();
+    let package_names: HashSet<&str> = package_info.iter().map(|pkg| pkg.name.as_str()).collect();
     let output = quiet_cmd!(
         sh,
         "cargo --locked tree --target=all --all-features --duplicates --edges no-dev --prefix depth"
@@ -409,9 +409,9 @@ fn check_clippy_toml_msrv(
     }
 
     // Check each package.
-    for (_package_name, package_dir) in packages {
+    for package in packages {
         for filename in CLIPPY_CONFIG_FILES {
-            let path = package_dir.join(filename);
+            let path = package.dir.join(filename);
             if path.exists() {
                 clippy_files.push(path);
             }

--- a/cargo-rbmt/src/main.rs
+++ b/cargo-rbmt/src/main.rs
@@ -29,7 +29,7 @@ struct Cli {
     #[arg(long, global = true, value_enum, default_value_t = LockFile::Recent)]
     lock_file: LockFile,
 
-    /// Filter to specific package (can be specified multiple times).
+    /// Filter which packages are operated on in the workspace. Can be a package's manifest name or directory.
     #[arg(short = 'p', long = "package", global = true)]
     packages: Vec<String>,
 

--- a/cargo-rbmt/src/prerelease.rs
+++ b/cargo-rbmt/src/prerelease.rs
@@ -51,34 +51,34 @@ pub fn run(
 ) -> Result<(), Box<dyn std::error::Error>> {
     quiet_println(&format!("Running pre-release checks on {} packages", packages.len()));
 
-    for (package_name, package_dir) in packages {
-        let config = PrereleaseConfig::load(Path::new(package_dir))?;
+    for package in packages {
+        let config = PrereleaseConfig::load(Path::new(&package.dir))?;
 
         if !config.enabled {
-            quiet_println(&format!("Skipping {package_name} (pre-release not enabled)"));
+            quiet_println(&format!("Skipping {} (pre-release not enabled)", package.name));
             continue;
         }
 
-        if !force && !has_version_bump(sh, package_dir, baseline)? {
+        if !force && !has_version_bump(sh, &package.dir, baseline)? {
             quiet_println(&format!(
-                "Skipping {package_name} (no version bump detected since {})",
-                baseline
+                "Skipping {} (no version bump detected since {})",
+                package.name, baseline
             ));
             continue;
         }
 
-        quiet_println(&format!("Checking package: {package_name}"));
+        quiet_println(&format!("Checking package: {}", package.name));
 
-        let _dir = sh.push_dir(package_dir);
+        let _dir = sh.push_dir(&package.dir);
 
         // Run all pre-release checks. Return immediately on first failure.
         if let Err(e) = check_todos(sh) {
-            eprintln!("Pre-release check failed for {package_name}: {e}");
+            eprintln!("Pre-release check failed for {}: {e}", package.name);
             return Err(e);
         }
 
         if let Err(e) = check_publish(sh) {
-            eprintln!("Pre-release check failed for {package_name}: {e}");
+            eprintln!("Pre-release check failed for {}: {e}", package.name);
             return Err(e);
         }
     }

--- a/cargo-rbmt/src/test.rs
+++ b/cargo-rbmt/src/test.rs
@@ -195,7 +195,11 @@ pub fn run(
             quiet_println(&format!("No commits found between '{}' and HEAD.", baseline));
             return Ok(());
         }
-        quiet_println(&format!("Testing {} commit(s) against baseline '{}'", commits.len(), baseline));
+        quiet_println(&format!(
+            "Testing {} commit(s) against baseline '{}'",
+            commits.len(),
+            baseline
+        ));
         for sha in &commits {
             quiet_println(&format!("Testing commit {}...", &sha[..12]));
             let _guard = git::GitSwitchGuard::new(sh, sha)?;
@@ -231,21 +235,20 @@ fn test_commit(
     let mut pkg_summaries = Vec::new();
 
     for package in packages {
-        let (package_name, package_dir) = package;
-        quiet_println(&format!("Testing package: {}", package_name));
+        quiet_println(&format!("Testing package: {}", package.name));
 
-        let _dir = sh.push_dir(package_dir);
+        let _dir = sh.push_dir(&package.dir);
         // prepare_toolchain is called per-package because MSRV is read from
         // each package's Cargo.toml individually rather than the workspace root.
         prepare_toolchain(sh, toolchain)?;
-        let config = TestConfig::load(Path::new(package_dir))?;
+        let config = TestConfig::load(Path::new(&package.dir))?;
         let release = release || config.release;
 
-        let mut pkg_summary = PackageSummary { name: package_name.clone(), ..Default::default() };
+        let mut pkg_summary = PackageSummary { name: package.name.clone(), ..Default::default() };
 
         do_test(sh, &config, release, &mut pkg_summary)?;
         do_feature_matrix(sh, package, &config, release, &mut pkg_summary)?;
-        do_no_std_check(sh, Path::new(package_dir), &mut pkg_summary)?;
+        do_no_std_check(sh, &package.dir, &mut pkg_summary)?;
 
         pkg_summaries.push(pkg_summary);
     }


### PR DESCRIPTION
Upgrade the Package type in cargo-rbmt to a full on struct and add the `id` field to hold the fully qualified pkgid. When filtering what packages to operate on with cargo, it is better to use the pkgid instead of the manifest name for scenarios where multiple versions of a package exist in a lock file.

This issue was exposed by https://github.com/rust-bitcoin/rust-bitcoin/pull/5554 where the fuzz package is updated to depend on an old version of `bitcoin` for test comparisons. This causes old versions of all the workspace's packages to be pinned in the lock file along side the current ones. So for example `base58ck` shows up once for the current filesystem version and once for whatever the old version of `bitcoin` was using (in this case, `0.1.0`).

This causes some weird to me breaks in cargo due to my model being a bit off. Maybe the simplest way to see it is the `pkgid` command, which works fine in the rust-bitcoin workspace before this fuzz patch with just the `base58ck` input. It now breaks due to ambiguity.

```shell
cargo pkgid base58ck
error: There are multiple `base58ck` packages in your project, and the specification `base58ck` is ambiguous.
Please re-run this command with one of the following specifications:
  base58ck@0.1.0
  base58ck@0.4.0
```

I assumed commands like this, and any package filtering like `cargo --locked doc --all-features --no-deps -p base58ck -p bitcoin-fuzz`, would be operating on *workspace packages*. But it appears they operate on *lock file packages*. So this patch fixes cargo-rbmt's ambiguity by referring to the workspace packages by their fully qualified names at all times since cargo-rbmt is designed to test these packages, not old deps.